### PR TITLE
fix: semantic release trigger fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches:
+      - main
       - semantic-release/*
 
 jobs:


### PR DESCRIPTION
## Summary
- Fix semantic release workflow to trigger on both `main` and `semantic-release/*` branches
- This ensures semantic release runs after merges to main to detect conventional commits and create release PRs

## Changes
- Updated `.github/workflows/release.yml` to trigger on both `main` and `semantic-release/*` branches
- Semantic release will now properly detect conventional commits on main and create release branches

## Test Plan
- [x] Merge this PR to main
- [ ] Verify semantic release workflow runs on main
- [ ] Confirm release PR is created for any conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)