### PR TITLE
feat: release-please versioning for monorepo

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+  "helm/football-pool": "0.1.0",
+  "frontend": "0.1.0",
+  "backend": "0.1.0"
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,8 @@ module github.com/dhpollack/football-pool
 // renovate: datasource=github-releases depName=golang/go versioning=semver allowedVersions=1.x
 go 1.25
 
+// version: 0.1.0
+
 // renovate: datasource=github-releases depName=golang/go versioning=semver allowedVersions=1.25.x
 toolchain go1.25.1
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,16 +1,15 @@
 {
   "packages": {
-    ".": {
-      "release-type": "helm",
-      "chart-path": "helm/football-pool",
-      "version-file": "helm/football-pool/Chart.yaml",
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "frontend/package.json",
-          "jsonpath": "$.version"
-        }
-      ]
+    "helm/football-pool": {
+      "release-type": "helm"
+    },
+    "frontend": {
+      "release-type": "node"
+    },
+    "backend": {
+      "release-type": "simple",
+      "version-file": "backend/go.mod",
+      "extra-files": []
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace semantic-release with release-please for better monorepo support
- Add coordinated versioning for all three packages: Helm chart, frontend, and backend
- Configure auto-merge friendly PR-based release workflow

## Changes
- **Removed**: semantic-release configuration and root package.json
- **Added**: release-please configuration for monorepo
- **Configured**: Three packages with coordinated versioning:
  - `helm/football-pool` (Helm chart)
  - `frontend` (Node.js package)
  - `backend` (Go module with version comment)
- **Added**: `.release-please-manifest.json` for version tracking
- **Updated**: Helm publish workflow to trigger on releases
- **Cleaned**: Removed unnecessary files and updated .dockerignore

## Test Plan
- [ ] Merge this PR to main
- [ ] Verify release-please workflow runs on main
- [ ] Confirm release PR is created for conventional commits
- [ ] Test auto-merge functionality
- [ ] Verify Helm chart gets published on releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)