### PR TITLE
chore: use pat instead of default token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,5 +19,4 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
-          token: ${{ secrets.GITHUB_TOKEN }}
-
+          token: ${{ secrets.GH_PAT_RELEASE_PLEASE }}


### PR DESCRIPTION
use pat token for release please to automerge