### PR TITLE
feat: add PVC for SQLite database persistence

### DIFF
--- a/helm/football-pool/templates/backend-deployment.yaml
+++ b/helm/football-pool/templates/backend-deployment.yaml
@@ -56,16 +56,27 @@ spec:
             httpGet:
               path: /api/health
               port: http
-          {{- if .Values.backend.usersTomlSecret.enabled }}
+          {{- if or .Values.backend.usersTomlSecret.enabled (and (not .Values.postgresql.enabled) .Values.backend.sqlite.persistence.enabled) }}
           volumeMounts:
+            {{- if .Values.backend.usersTomlSecret.enabled }}
             - name: users-toml
               mountPath: "/app/config/users.toml"
               subPath: "users.toml"
               readOnly: true
+            {{- end }}
+            {{- if and (not .Values.postgresql.enabled) .Values.backend.sqlite.persistence.enabled }}
+            - name: sqlite-data
+              mountPath: "/app/data"
+            {{- end }}
           {{- end }}
-      {{- if .Values.backend.usersTomlSecret.enabled }}
       volumes:
+        {{- if .Values.backend.usersTomlSecret.enabled }}
         - name: users-toml
           secret:
             secretName: {{ .Values.backend.usersTomlSecret.secretName }}
-      {{- end }}
+        {{- end }}
+        {{- if and (not .Values.postgresql.enabled) .Values.backend.sqlite.persistence.enabled }}
+        - name: sqlite-data
+          persistentVolumeClaim:
+            claimName: {{ include "football-pool.fullname" . }}-sqlite
+        {{- end }}

--- a/helm/football-pool/templates/sqlite-pvc.yaml
+++ b/helm/football-pool/templates/sqlite-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and (not .Values.postgresql.enabled) .Values.backend.sqlite.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "football-pool.fullname" . }}-sqlite
+  labels:
+    {{- include "football-pool.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.backend.sqlite.persistence.size | default "128Mi" }}
+  {{- if .Values.backend.sqlite.persistence.storageClass }}
+  storageClassName: {{ .Values.backend.sqlite.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/helm/football-pool/values.yaml
+++ b/helm/football-pool/values.yaml
@@ -20,6 +20,12 @@ backend:
     enabled: false
     secretName: "" # Name of the secret containing the users.toml file
 
+  sqlite:
+    persistence:
+      enabled: true
+      size: "128Mi"
+      # storageClass: "" # Optional: specify a storage class
+
 frontend:
   image:
     repository: football-pool-frontend


### PR DESCRIPTION
## Summary
- Add PersistentVolumeClaim template for SQLite data storage
- Update backend deployment to mount SQLite PVC at /app/data  
- Configure default 128MB storage for SQLite database
- Enable SQLite persistence by default when PostgreSQL is disabled

## Test plan
- [ ] Deploy with PostgreSQL disabled and verify SQLite PVC is created
- [ ] Verify backend pod mounts the PVC at /app/data
- [ ] Test data persistence by restarting the backend pod
- [ ] Verify SQLite database files persist across pod restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)